### PR TITLE
For Debian (Jessie) Linux compile, needed to append "-I/usr/include/f…

### DIFF
--- a/Builds/Linux/Makefile
+++ b/Builds/Linux/Makefile
@@ -26,7 +26,7 @@ ifeq ($(CONFIG),Debug)
     TARGET_ARCH := -march=native
   endif
 
-  JUCE_CPPFLAGS := $(DEPFLAGS) -DLINUX=1 -DDEBUG=1 -D_DEBUG=1 -DJUCER_LINUX_MAKE_7346DA2A=1 -DJUCE_APP_VERSION=0.2.4 -DJUCE_APP_VERSION_HEX=0x204 -pthread -I../../JuceLibraryCode -I../../JuceLibraryCode/modules
+  JUCE_CPPFLAGS := $(DEPFLAGS) -DLINUX=1 -DDEBUG=1 -D_DEBUG=1 -DJUCER_LINUX_MAKE_7346DA2A=1 -DJUCE_APP_VERSION=0.2.4 -DJUCE_APP_VERSION_HEX=0x204 -pthread -I../../JuceLibraryCode -I../../JuceLibraryCode/modules -I/usr/include/freetype2
   JUCE_CFLAGS += $(CFLAGS) $(JUCE_CPPFLAGS) $(TARGET_ARCH) -g -ggdb -O0
   JUCE_CXXFLAGS += $(CXXFLAGS) $(JUCE_CFLAGS) -std=c++11
   JUCE_LDFLAGS += $(LDFLAGS) $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR) -L/usr/X11R6/lib/ -lGL -lX11 -lXext -lXinerama -lasound -ldl -lfreetype -lpthread -lrt 


### PR DESCRIPTION
…reetype2" path to JUCE_CPPFLAGS line in Makefile.

Builds now, but not currently able to test.